### PR TITLE
fix(ci): allow checkout of fork PR code in pull_request_target workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
           submodules: false
           fetch-depth: 0
           persist-credentials: false
+          # pull_request_target 需要检出 fork 代码以在 Docker 中编译测试。
+          # 安全保障：fork PR 不会发布 coverage，secrets 仅用于 GHCR 镜像拉取。
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Resolve image reference
         id: image


### PR DESCRIPTION
actions/checkout@v4 now refuses to check out fork PR refs from a pull_request_target workflow by default, to prevent pwn-request attacks.

Add allow-unsafe-pr-checkout conditionally for pull_request_target events. This is safe because fork PRs do not publish coverage or access secrets beyond GHCR image pulls, and fork code only runs inside a Docker container.